### PR TITLE
Make keyserver configurable and fix faraday (berkshelf version bump)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.2.4'
+gem 'berkshelf', '~> 4.0.1'
 gem 'test-kitchen', '~> 1.4.0'
 gem 'foodcritic', '4.0.0'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,9 @@ default['mongodb3']['mongos']['config_file'] = '/etc/mongos.conf'
 # Key file contents
 default['mongodb3']['config']['key_file_content'] = nil
 
+# Key server
+default['mongodb3']['keyserver'] = 'hkp://keyserver.ubuntu.com:80'
+
 # Mongod config
 # The default value of the attribute is referred to the MongoDB documentation.
 # The attribute value of nil will be removed from mongod config file.

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -33,7 +33,7 @@ case node['platform_family']
       uri 'http://repo.mongodb.org/apt/ubuntu'
       distribution "#{node['lsb']['codename']}/mongodb-org/stable"
       components ['multiverse']
-      keyserver 'hkp://keyserver.ubuntu.com:80'
+      keyserver node['mongodb3']['keyserver']
       key '7F0CEB10'
       action :add
     end


### PR DESCRIPTION
Allow for the default keyserver.ubuntu.com keyserver override.
