### PR TITLE
allowed overrides of mongo repo name for debian/ubuntu packages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,9 @@ end
 # MongoDB package repo url
 default['mongodb3']['package']['repo']['url'] = pkg_repo
 
+# MongoDB repository name
+default['mongodb3']['package']['repo']['apt']['name'] = "stable"
+
 # MongoDB apt keyserver and key
 default['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
 default['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -31,7 +31,8 @@ case node['platform_family']
   when 'debian'
     apt_repository 'mongodb' do
       uri node['mongodb3']['package']['repo']['url']
-      distribution "#{node['lsb']['codename']}/mongodb-org/stable"
+#      distribution "#{node['lsb']['codename']}/mongodb-org/stable"
+      distribution "#{node['lsb']['codename']}/mongodb-org/#{node['mongodb3']['package']['repo']['apt']['name']}"
       components node['mongodb3']['package']['repo']['apt']['components']
       keyserver node['mongodb3']['package']['repo']['apt']['keyserver']
       key node['mongodb3']['package']['repo']['apt']['key']

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -31,7 +31,6 @@ case node['platform_family']
   when 'debian'
     apt_repository 'mongodb' do
       uri node['mongodb3']['package']['repo']['url']
-#      distribution "#{node['lsb']['codename']}/mongodb-org/stable"
       distribution "#{node['lsb']['codename']}/mongodb-org/#{node['mongodb3']['package']['repo']['apt']['name']}"
       components node['mongodb3']['package']['repo']['apt']['components']
       keyserver node['mongodb3']['package']['repo']['apt']['keyserver']


### PR DESCRIPTION
I ran into challenges installing older 3.0 versions from the stable repo and needed a way to override the value. This allows what I need but has the reasonable default of "stable".

Thanks for a great cookbook!
Dave
