### PR TITLE
Support for both Mongodb 30 and 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Install and configure the MongoDB 3
 NOTICE :
 * Current version 3.0.0 is not supporting mongos 3.0.7 for Oracle Linux 6.6. The package version 3.0.7-1.el6 of mongodb-org-shell package wasn't existing (Test failure).
 * Current version 3.0.0 is not supporting automation and monitoring mms agent installation for Debian 7.8
+* Support MongoDB 3.2.0 version - by [@Cog_g](https://github.com/Cog-g)
 
 ## Supported Platforms
 
@@ -31,7 +32,7 @@ WARNING : Please do not set the user and group attribute on your side. This cook
 
 ```
 # MongoDB version to install
-default['mongodb3']['version'] = '3.0.7'
+default['mongodb3']['version'] = '3.2.0'
 default['mongodb3']['package']['version'] = Actual package version to install. It builds from version attribute.
 
 # Package repository url
@@ -39,7 +40,7 @@ default['mongodb3']['package']['repo']['url'] = Package repository url
 
 # Attribute for apt_repository
 default['mongodb3']['package']['repo']['apt']['keyserver'] = key server url for ubuntu or debian
-default['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
+default['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
 default['mongodb3']['package']['repo']['apt']['components'] = `multiverse` for ubuntu. `main` for debian
 
 # MongoDB user:group : PLEASE DO NOT SET THE USER AND GROUP ATTRIBUTE

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,7 +179,11 @@ default['mongodb3']['config']['mongod']['storage']['repairPath'] = nil
 default['mongodb3']['config']['mongod']['storage']['journal']['enabled'] = true
 default['mongodb3']['config']['mongod']['storage']['directoryPerDB'] = nil # default : false
 default['mongodb3']['config']['mongod']['storage']['syncPeriodSecs'] = nil # default : 60
-default['mongodb3']['config']['mongod']['storage']['engine'] = 'mmapv1'
+if node['mongodb3']['version'] == '3.2.0'
+  default['mongodb3']['config']['mongod']['storage']['engine'] = 'wiredTiger' # default since 3.2 : wiredTiger
+else
+  default['mongodb3']['config']['mongod']['storage']['engine'] = 'mmapv1' # default until 3.2 : mmapv1
+end
 
 # storage.mmapv1 Options : http://docs.mongodb.org/manual/reference/configuration-options/#storage-mmapv1-options
 default['mongodb3']['config']['mongod']['storage']['mmapv1']['preallocDataFiles'] = nil # default : true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ case node['platform_family']
       pkg_version = "#{node['mongodb3']['version']}-1.amzn1" # ~FC019
     end
 end
+pkg_major_version = pkg_version.to_f # eg. 3.0, 3.2
 
 # Setup default package repo url attribute for each platform family or platform
 case node['platform']
@@ -71,9 +72,16 @@ end
 # MongoDB package repo url
 default['mongodb3']['package']['repo']['url'] = pkg_repo
 
+# MongoDB repository name
+default['mongodb3']['package']['repo']['apt']['name'] = pkg_major_version.to_s
+
 # MongoDB apt keyserver and key
 default['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
-default['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
+if pkg_major_version >= 3.2
+  default['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
+else
+  default['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
+end
 default['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
 
 # MongoDB package version to install
@@ -179,7 +187,7 @@ default['mongodb3']['config']['mongod']['storage']['repairPath'] = nil
 default['mongodb3']['config']['mongod']['storage']['journal']['enabled'] = true
 default['mongodb3']['config']['mongod']['storage']['directoryPerDB'] = nil # default : false
 default['mongodb3']['config']['mongod']['storage']['syncPeriodSecs'] = nil # default : 60
-if node['mongodb3']['version'] == '3.2.0'
+if pkg_major_version >= 3.2
   default['mongodb3']['config']['mongod']['storage']['engine'] = 'wiredTiger' # default since 3.2 : wiredTiger
 else
   default['mongodb3']['config']['mongod']['storage']['engine'] = 'mmapv1' # default until 3.2 : mmapv1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 # MongoDB version to install
-default['mongodb3']['version'] = '3.0.7'
+default['mongodb3']['version'] = '3.2.0'
 
 # Setup default package version attribute to install
 pkg_version = node['mongodb3']['version']
@@ -73,7 +73,7 @@ default['mongodb3']['package']['repo']['url'] = pkg_repo
 
 # MongoDB apt keyserver and key
 default['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
-default['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
+default['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
 default['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
 
 # MongoDB package version to install

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -31,7 +31,7 @@ case node['platform_family']
   when 'debian'
     apt_repository 'mongodb' do
       uri node['mongodb3']['package']['repo']['url']
-      distribution "#{node['lsb']['codename']}/mongodb-org/stable"
+      distribution "#{node['lsb']['codename']}/mongodb-org/3.2"
       components node['mongodb3']['package']['repo']['apt']['components']
       keyserver node['mongodb3']['package']['repo']['apt']['keyserver']
       key node['mongodb3']['package']['repo']['apt']['key']

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -31,7 +31,7 @@ case node['platform_family']
   when 'debian'
     apt_repository 'mongodb' do
       uri node['mongodb3']['package']['repo']['url']
-      distribution "#{node['lsb']['codename']}/mongodb-org/3.2"
+      distribution "#{node['lsb']['codename']}/mongodb-org/#{node['mongodb3']['package']['repo']['apt']['name']}"
       components node['mongodb3']['package']['repo']['apt']['components']
       keyserver node['mongodb3']['package']['repo']['apt']['keyserver']
       key node['mongodb3']['package']['repo']['apt']['key']


### PR DESCRIPTION
This PR builds on #16 to restore support for MongoDB 3.0 (MongoDB 3.2 has not been evaluated by us yet, so we want to stay on 3.0 for now; however the previous 'stable' repository is now pointing to 3.2 with new signing key so old version of this cookbook does not work anymore out of the box).

It recycles the `node['mongodb3']['package']['repo']['apt']['name']` attribute proposed in #14.

It handles the difference of installation between the 2 major versions, which are:
- change of apt repository name.
- change of signing keys.
