### PR TITLE
Fix #21: Chef::Mixin::Template::TemplateError: Node attributes are read-only when you do not specify which precedence level to set with Chef 11.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_script:
   - bundle exec berks
 script:
   - bundle exec foodcritic .
+  - bundle exec rspec test/libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mongodb3 Cookbook CHANGELOG
 
+## Next
+* Fixed Chef::Mixin::Template::TemplateError: Node attributes are read-only when you do not specify which precedence level to set with Chef 11.10 - Daniel Doubrovkine([@dblock](https://github.com/dblock)) #21.
+
 ## 4.0.0
 Thank you so much for your contribution!
 * Allowed overrides of mongo repo name for debian/ubuntu packages - Dave Augustus([@daugustus](https://github.com/daugustus))
@@ -16,7 +19,7 @@ Thank you so much for your contribution!
 
 NOTICE :
 * Current version 3.0.0 is not supporting mongos 3.0.7 for Oracle Linux 6.6. The package version 3.0.7-1.el6 of mongodb-org-shell package wasn't existing (Test failure).
-* Current version 3.0.0 is not supporting automation and monitoring mms agent installation for Debian 7.8 
+* Current version 3.0.0 is not supporting automation and monitoring mms agent installation for Debian 7.8
 
 ## 2.0.0
 
@@ -24,7 +27,7 @@ WARNING : `mms-agent` recipe has been deprecated at this version.
 
 * Removing `mongodb-org` package installation : `mongodb-org` package installs latest version of mongodb modules such as `mongodb-org-server`. so that installing lower version of mongodb-org-server has been failed.
 * Removing `mms-agent` recipe and divide it as `mms-automation-agent` and `mms-monitoring-agent` recipe
-* PR #3 : Bump up the runit dependency version to 1.7.0. Thank you for your contribution @dherges 
+* PR #3 : Bump up the runit dependency version to 1.7.0. Thank you for your contribution @dherges
 
 
 ## 1.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,8 @@ gem 'foodcritic', '4.0.0'
 group :integration do
   gem 'kitchen-vagrant', '~> 0.18.0'
 end
+
+group :test do
+  gem 'chef', '11.10'
+  gem 'rspec', '~> 3.1'
+end

--- a/libraries/mongodb3_helper.rb
+++ b/libraries/mongodb3_helper.rb
@@ -7,7 +7,12 @@ end
 class Hash
   def compact
     inject({}) do |new_hash, (k, v)|
-      new_hash[k] = v.is_a?(Hash) ? v.compact : v unless v.nil?
+      if v.is_a?(Hash)
+        v = v.compact
+        new_hash[k] = v unless v.empty?
+      else
+        new_hash[k] = v unless v.nil?
+      end
       new_hash
     end
   end

--- a/libraries/mongodb3_helper.rb
+++ b/libraries/mongodb3_helper.rb
@@ -1,14 +1,14 @@
-
 module Mongodb3Helper
   def mongodb_config(config)
-    config_hash = config.to_hash
-    config_hash.compact
-    JSON.parse(config_hash.dup.to_json).to_yaml
+    config.to_hash.compact.to_yaml
   end
 end
 
 class Hash
   def compact
-    delete_if {|k,v| v.is_a?(Hash) ? v.compact.empty? : v.nil? }
+    inject({}) do |new_hash, (k, v)|
+      new_hash[k] = v.is_a?(Hash) ? v.compact : v unless v.nil?
+      new_hash
+    end
   end
 end

--- a/test/libraries/mongodb3_helper_spec.rb
+++ b/test/libraries/mongodb3_helper_spec.rb
@@ -9,7 +9,7 @@ describe 'Mongodb3Helper' do
     end
   end
   context '#mongodb_config' do
-    let(:config) { Chef::Node::ImmutableMash.new('systemLog' => { 'verbosity' => nil, 'path' => '/var/log' }) }
+    let(:config) { Chef::Node::ImmutableMash.new('systemLog' => { 'verbosity' => nil, 'path' => '/var/log', 'empty' => { 'foo' => nil } }) }
     it 'with an immutable Mash' do
       expect(YAML.load(subject.mongodb_config(config))).to eq('systemLog' => { 'path' => '/var/log' })
     end

--- a/test/libraries/mongodb3_helper_spec.rb
+++ b/test/libraries/mongodb3_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'chef'
+require 'chef/node/immutable_collections'
+require './libraries/mongodb3_helper'
+
+describe 'Mongodb3Helper' do
+  subject do
+    Class.new do
+      extend Mongodb3Helper
+    end
+  end
+  context '#mongodb_config' do
+    let(:config) { Chef::Node::ImmutableMash.new('systemLog' => { 'verbosity' => nil, 'path' => '/var/log' }) }
+    it 'with an immutable Mash' do
+      expect(subject.mongodb_config(config)).to eq("---\nsystemLog:\n  path: /var/log\n")
+    end
+  end
+end

--- a/test/libraries/mongodb3_helper_spec.rb
+++ b/test/libraries/mongodb3_helper_spec.rb
@@ -11,7 +11,7 @@ describe 'Mongodb3Helper' do
   context '#mongodb_config' do
     let(:config) { Chef::Node::ImmutableMash.new('systemLog' => { 'verbosity' => nil, 'path' => '/var/log' }) }
     it 'with an immutable Mash' do
-      expect(subject.mongodb_config(config)).to eq("---\nsystemLog:\n  path: /var/log\n")
+      expect(YAML.load(subject.mongodb_config(config))).to eq('systemLog' => { 'path' => '/var/log' })
     end
   end
 end


### PR DESCRIPTION
This happens with Chef 11.10. The root cause of the bug is that `ImmutableMash#to_hash` was returning a `Hash` that contained deep `ImmutableMash` elements. It was fixed in https://github.com/chef/chef/commit/b741b87b81f82587800da5329b47cfd414b3301d, however the implementation here trying to modify the underlying hash is still a bad idea.
- We no longer require doing `JSON.parse(config_hash.dup.to_json)` which served the purpose of stripping classes such as `!ruby/hash:Chef::Node::ImmutableMash` from the YAML - we can just make a new Hash here and call it a day. I think this works in all cases, but I could be wrong.
- Added RSpec and a test for `Mongodb3Helper`
