### PR TITLE
Improve upgrade of deb package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,9 +22,18 @@ include_recipe 'mongodb3::package_repo'
 # Install MongoDB package
 install_package = %w(mongodb-org-server mongodb-org-shell mongodb-org-tools)
 
+case node['platform_family']
+    when 'debian'
+      # bypass dpkg errors about pre-existing init or conf file
+      packager_opts = '-o Dpkg::Options::="--force-confold" --force-yes'
+    else
+      packager_opts = ''
+end
+
 install_package.each do |pkg|
   package pkg do
     version node['mongodb3']['package']['version']
+    options packager_opts
     action :install
   end
 end


### PR DESCRIPTION
Pass `-o Dpkg::Options::="--force-confold" --force-yes` as options to `package` so that dpkg won't generate errors about pre-existing /etc/init.d/mongod or /etc/mongod.conf file(s).

This allow more robust upgrade path : if a previous mongodb package is already installed in the node it will allow transparent upgrade.
