### PR TITLE
allow override of the cookbook used for runit templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ default['mongodb3']['mongod']['config_file'] = '/etc/mongod.conf'
 # Mongos config file path
 default['mongodb3']['mongos']['config_file'] = '/etc/mongos.conf'
 
+# Cookbook for init scripts
+default['mongodb3']['service_template_cookbook'] = 'mongodb3'
+
 # Key file contents
 default['mongodb3']['config']['key_file_content'] = nil
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,9 @@ end
 default['mongodb3']['user'] = mongo_user
 default['mongodb3']['group'] = mongo_group
 
+# Cookbook for init scripts
+default['mongodb3']['service_template_cookbook'] = 'mongodb3'
+
 # Mongod config file
 default['mongodb3']['mongod']['config_file'] = '/etc/mongod.conf'
 

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -81,6 +81,7 @@ include_recipe 'runit::default'
 runit_service 'mongos' do
   retries 3
   restart_on_update true
+  cookbook node['mongodb3']['service_template_cookbook']
   options ({
               :user => node['mongodb3']['user'],
               :config_file => node['mongodb3']['mongos']['config_file']


### PR DESCRIPTION
This allows custom templates for the run it service (use case: lets us set ulimit settings and such)
