### PR TITLE
Test with Chef 12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.0
+- 2.3.1
 bundler_args: --without integration
 gemfile:
   - Gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mongodb3 Cookbook CHANGELOG
 
+## Next
+
+* PR #49 : Test with Chef 12.x
+
 ## 5.3.0
 
 Thank you so much for your huge contribution on this release!
@@ -13,7 +17,7 @@ Thank you so much for your huge contribution on this release!
 * PR #40 : Allow override of the cookbook used for mongos runit templates. Popsikle([@popsikle](https://github.com/popsikle))
 * PR #41 : Create and set ownership of data directory for mms-automation-agent. Amsdard([@amsdard](https://github.com/amsdard))
 * Adding support Ubuntu 15.04 and 16.04 for MMS Automation and Monitoring Agent.
-* Testing in CentOS 6.8. 
+* Testing in CentOS 6.8.
  * 6.6 was missing in bento.
 * No longer support Chef Client version 11.
  * Chef Client version issue related to Custom Resources
@@ -27,7 +31,7 @@ Thank you so much for your huge contribution on this release!
 
 ## 5.1.0
 
-* Feature request #31 : Creating sysLog directory for mongod 
+* Feature request #31 : Creating sysLog directory for mongod
 * Fixing #30 : Changing service provider as `Chef::Provider::Service::Upstart` for ubuntu 14.04
 
 ## 5.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :integration do
 end
 
 group :test do
-  gem 'chef', '11.10'
+  gem 'chef', '~> 12.14'
   gem 'rspec', '~> 3.1'
 end

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * Install and configure the mongod (or configure the config server for shard cluster)
 * Install and configure the mongos
- * Also, mongos configure the mongos service with runit : `service mongos start|stop|restart|status` 
+ * Also, mongos configure the mongos service with runit : `service mongos start|stop|restart|status`
 * Install and configure the MMS Automation Agent
 * Install and configure the MMS Monitoring Agent
 
@@ -31,6 +31,7 @@
 * Marcin Skurski - [@mskurski](https://github.com/mskurski)
 * Popsikle - [@popsikle](https://github.com/popsikle)
 * Amsdard - [@amsdard](https://github.com/amsdard)
+* Grant Ridder - [@shortdudey123](https://github.com/shortdudey123)
 
 ## Supported Platforms
 


### PR DESCRIPTION
Since support for Chef 11.x was dropped, testing should not still rely on it.
