### PR TITLE
add a ['mongodb3']['package']['configure_repo'] attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,9 @@ default['mongodb3']['version'] = '3.2.8'
 # MongoDB package version to install : eg. 3.0.8, 3.2.1, 3.2.1-1.el6 or 3.2.1-1.amzn1
 default['mongodb3']['package']['version'] = nil
 
+# Should we configure the package repo for your distro's package manager?
+default['mongodb3']['package']['configure_repo'] = true
+
 # MongoDB package repo url
 # eg. ubuntu : 'http://repo.mongodb.org/apt/ubuntu'
 # eg. centos : 'https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sunggun.dev@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures mongodb3'
 long_description 'Installs/Configures mongodb3'
-version          '5.3.0'
+version          '5.4.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '= 7.8'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sunggun.dev@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures mongodb3'
 long_description 'Installs/Configures mongodb3'
-version          '5.4.0'
+version          '5.3.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '= 7.8'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'mongodb3::package_repo'
+include_recipe 'mongodb3::package_repo' if node['mongodb3']['package']['configure_repo']
 
 # Install MongoDB package
 install_package = %w(mongodb-org-server mongodb-org-shell mongodb-org-tools)

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'mongodb3::package_repo'
+include_recipe 'mongodb3::package_repo' if node['mongodb3']['package']['configure_repo']
 
 # Install Mongos package
 install_package = %w(mongodb-org-shell mongodb-org-mongos mongodb-org-tools)


### PR DESCRIPTION
Add a ['mongodb3']['package']['configure_repo'] attribute to allow control of whether or not to configure the package repo.  In some environments, a machine might not have access to external repos and may get its packages from an already configured repo.
