### PR TITLE
Allow downloading of custom agent binaries from a custom host

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -235,6 +235,8 @@ default['mongodb3']['config']['mms']['mmsConfigBackup'] = '/var/lib/mongodb-mms-
 default['mongodb3']['config']['mms']['logLevel'] = 'INFO'
 default['mongodb3']['config']['mms']['maxLogFiles'] = 10
 default['mongodb3']['config']['mms']['maxLogFileSize'] = 268435456
+default['mongodb3']['config']['mms']['agent_version'] = 'latest'
+default['mongodb3']['config']['mms']['agent_download_host'] = 'https://cloud.mongodb.com'
 
 ## Attributes for monitoring agent
 default['mongodb3']['config']['mms']['useSslForAllConnections'] = nil

--- a/recipes/mms_automation_agent.rb
+++ b/recipes/mms_automation_agent.rb
@@ -23,17 +23,19 @@ package 'curl' do
 end
 
 # Set variables by platform
+version = node['mongodb3']['config']['mms']['agent_version']
+host = node['mongodb3']['config']['mms']['agent_download_host']
 case node['platform_family']
   when 'rhel', 'fedora'
-    mms_agent_source = 'https://cloud.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager-latest.x86_64.rpm'
-    mms_agent_file = '/root/mongodb-mms-automation-agent-manager-latest.x86_64.rpm'
+    mms_agent_source = "#{host}/download/agent/automation/mongodb-mms-automation-agent-manager-#{version}.x86_64.rpm"
+    mms_agent_file = "/root/mongodb-mms-automation-agent-manager-#{version}.x86_64.rpm"
   when 'debian'
     if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 15.04
-      mms_agent_source = 'https://cloud.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager_latest_amd64.ubuntu1604.deb'
-      mms_agent_file = '/root/mongodb-mms-automation-agent-manager_latest_amd64.ubuntu1604.deb'
+      mms_agent_source = "#{host}/download/agent/automation/mongodb-mms-automation-agent-manager_#{version}_amd64.ubuntu1604.deb"
+      mms_agent_file = "/root/mongodb-mms-automation-agent-manager_#{version}_amd64.ubuntu1604.deb"
     else
-      mms_agent_source = 'https://cloud.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager_latest_amd64.deb'
-      mms_agent_file = '/root/mongodb-mms-automation-agent-manager_latest_amd64.deb'
+      mms_agent_source = "#{host}/download/agent/automation/mongodb-mms-automation-agent-manager_#{version}_amd64.deb"
+      mms_agent_file = "/root/mongodb-mms-automation-agent-manager_#{version}_amd64.deb"
     end
 end
 


### PR DESCRIPTION
We are locking into a specific version and storing the RPMs in Artifactory