### PR TITLE
Added support for 3.4 version

### DIFF
--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -35,6 +35,12 @@ user node['mongodb3']['user'] do
   action :create
 end
 
+# Depricated variables
+if node['mongodb3']['version'].to_f >= 3.4
+  node.rm('mongodb3','config','mongos','sharding','autoSplit')
+  node.rm('mongodb3','config','mongos','sharding','chunkSize')
+end
+
 # Create the Mongos config file
 template node['mongodb3']['mongos']['config_file'] do
   source 'mongodb.conf.erb'

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -72,7 +72,9 @@ if node['mongodb3']['package']['repo']['apt']['keyserver'].nil?
 end
 
 if node['mongodb3']['package']['repo']['apt']['key'].nil?
-  if pkg_major_version >= 3.2
+  if pkg_major_version >= 3.4
+    node.set['mongodb3']['package']['repo']['apt']['key'] = '0C49F3730359A14518585931BC711F9BA15703C6'
+  elsif pkg_major_version >= 3.2
     node.set['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
   else
     node.set['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'


### PR DESCRIPTION
mongos:sharding:autoSplit and sharding:chunkSize are no longer supported on 3.4 and cause mongos to fail if they're set