### PR TITLE
Updating case statements to include amazon as a platform family (as used in Chef 13)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,7 @@ default['mongodb3']['package']['repo']['apt']['components'] = nil # eg. ['multiv
 
 # Default attribute for MongoDB installation
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     mongo_user = 'mongod'
     mongo_group = 'mongod'
     mongo_dbpath = '/var/lib/mongo'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,9 @@ maintainer_email 'sunggun.dev@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures mongodb3'
 long_description 'Installs/Configures mongodb3'
-version          '5.3.0'
+
+version '5.3.0'
+chef_version '>= 12', '< 14.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '= 7.8'

--- a/recipes/mms_automation_agent.rb
+++ b/recipes/mms_automation_agent.rb
@@ -24,7 +24,7 @@ end
 
 # Set variables by platform
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     mms_agent_source = 'https://cloud.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager-latest.x86_64.rpm'
     mms_agent_file = '/root/mongodb-mms-automation-agent-manager-latest.x86_64.rpm'
   when 'debian'
@@ -48,7 +48,7 @@ end
 
 # Install package
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     rpm_package 'mongodb-mms-automation-agent-manager' do
       source mms_agent_file
       action :install

--- a/recipes/mms_monitoring_agent.rb
+++ b/recipes/mms_monitoring_agent.rb
@@ -24,7 +24,7 @@ end
 
 # Set variables by platform
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     mms_agent_source = 'https://cloud.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent-latest.x86_64.rpm'
     mms_agent_file = '/root/mongodb-mms-monitoring-agent-latest.x86_64.rpm'
   when 'debian'
@@ -45,7 +45,7 @@ end
 
 # Install package
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     rpm_package 'mongodb-mms-monitoring-agent' do
       source mms_agent_file
       action :install

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -72,7 +72,7 @@ if node['platform'] == 'oracle'
     action :create
   end
   # Set `['runit']['prefer_local_yum'] = true` to avoid install yum repository through packagecloud cookbook
-  node.set['runit']['prefer_local_yum'] = true
+  node.override['runit']['prefer_local_yum'] = true
 end
 
 # Install runit service package through runit::default recipe

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -55,34 +55,34 @@ end
 
 # MongoDB package version to install
 if node['mongodb3']['package']['version'].nil?
-  node.set['mongodb3']['package']['version'] = pkg_version
+  node.override['mongodb3']['package']['version'] = pkg_version
 end
 
 # MongoDB package repo url
 if node['mongodb3']['package']['repo']['url'].nil?
-  node.set['mongodb3']['package']['repo']['url'] = pkg_repo
+  node.override['mongodb3']['package']['repo']['url'] = pkg_repo
 end
 
 # MongoDB repository name
 if node['mongodb3']['package']['repo']['apt']['name'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['name'] = pkg_major_version.to_s
+  node.override['mongodb3']['package']['repo']['apt']['name'] = pkg_major_version.to_s
 end
 
 # MongoDB apt keyserver and key
 if node['mongodb3']['package']['repo']['apt']['keyserver'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
+  node.override['mongodb3']['package']['repo']['apt']['keyserver'] = apt_repo_keyserver
 end
 
 if node['mongodb3']['package']['repo']['apt']['key'].nil?
   if pkg_major_version >= 3.2
-    node.set['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
+    node.override['mongodb3']['package']['repo']['apt']['key'] = 'EA312927'
   else
-    node.set['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
+    node.override['mongodb3']['package']['repo']['apt']['key'] = '7F0CEB10'
   end
 end
 
 if node['mongodb3']['package']['repo']['apt']['components'].nil?
-  node.set['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
+  node.override['mongodb3']['package']['repo']['apt']['components'] = apt_repo_component
 end
 
 # Add the MongoDB Package repository

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -27,6 +27,9 @@ case node['platform_family']
     if node['platform'] == 'amazon'
       pkg_version = "#{node['mongodb3']['version']}-1.amzn1" # ~FC019
     end
+  when 'amazon'
+    pkg_version = "#{node['mongodb3']['version']}-1.amzn1" # ~FC019
+  end
 end
 
 # Setup default package repo url attribute for each platform family or platform
@@ -85,7 +88,7 @@ end
 
 # Add the MongoDB Package repository
 case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     yum_repository "mongodb-org-#{pkg_major_version}" do
       description 'MongoDB Repository'
       baseurl node['mongodb3']['package']['repo']['url']

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -29,7 +29,6 @@ case node['platform_family']
     end
   when 'amazon'
     pkg_version = "#{node['mongodb3']['version']}-1.amzn1" # ~FC019
-  end
 end
 
 # Setup default package repo url attribute for each platform family or platform

--- a/test/cookbooks/mongodb3-test/recipes/custom.rb
+++ b/test/cookbooks/mongodb3-test/recipes/custom.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-node.set['mongodb3']['config']['mongod']['storage']['dbPath'] = '/var/lib/mongodb/custom'
-node.set['mongodb3']['config']['mongod']['systemLog']['path'] = '/var/log/mongodb/custom/mongod.log'
+node.override['mongodb3']['config']['mongod']['storage']['dbPath'] = '/var/lib/mongodb/custom'
+node.override['mongodb3']['config']['mongod']['systemLog']['path'] = '/var/log/mongodb/custom/mongod.log'
 
 include_recipe 'mongodb3::default'

--- a/test/cookbooks/mongodb3-test/recipes/default-30x.rb
+++ b/test/cookbooks/mongodb3-test/recipes/default-30x.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-node.set['mongodb3']['version'] = '3.0.11'
+node.override['mongodb3']['version'] = '3.0.11'
 
 # For package upgrade testing : executing converge twice with different version
-# node.set['mongodb3']['version'] = '3.2.4'
-# node.set['mongodb3']['package']['version'] = '3.2.4'
-# node.set['mongodb3']['package']['repo']['apt']['name'] = '3.2'
+# node.override['mongodb3']['version'] = '3.2.4'
+# node.override['mongodb3']['package']['version'] = '3.2.4'
+# node.override['mongodb3']['package']['repo']['apt']['name'] = '3.2'
 
 include_recipe 'mongodb3::default'

--- a/test/cookbooks/mongodb3-test/recipes/mms_automation_agent_with_data_bag.rb
+++ b/test/cookbooks/mongodb3-test/recipes/mms_automation_agent_with_data_bag.rb
@@ -34,7 +34,7 @@
 mms_data_bag_item = Chef::EncryptedDataBagItem.load('mongodb', 'mms-agent')
 mms_data_bag = mms_data_bag_item['environments'][node.chef_environment]
 
-node.set['mongodb3']['config']['mms']['mmsGroupId'] = mms_data_bag['mms_group_id']
-node.set['mongodb3']['config']['mms']['mmsApiKey'] = mms_data_bag['mms_api_key']
+node.override['mongodb3']['config']['mms']['mmsGroupId'] = mms_data_bag['mms_group_id']
+node.override['mongodb3']['config']['mms']['mmsApiKey'] = mms_data_bag['mms_api_key']
 
 include_recipe 'mongodb3::mms_automation_agent'


### PR DESCRIPTION
- Updating case statements to include 'amazon' as a platform family

- Keeping platform option in line 27 of the package_repo.rb recipe for backwards compatability with Chef 12 where amazon-linux falls under the 'rhel' platform_family